### PR TITLE
Compile zlib static library with -fPIC

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CFLAGS="-fPIC -O3" ./configure --shared --prefix=$PREFIX
+CFLAGS="-fPIC" ./configure --shared --prefix=$PREFIX
 
 make
 make check

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-./configure --shared --prefix=$PREFIX
+CFLAGS="-fPIC -O3" ./configure --shared --prefix=$PREFIX
 
 make
 make check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d
 
 build:
-    number: 0
+    number: 1
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]


### PR DESCRIPTION
Same issue as conda-forge/snappy-feedstock#1. With these patches I'm able to link a shared library (apache/parquet-cpp) that depends on static libs for both snappy and zlib. 
