### PR TITLE
Clobber defauts build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d
 
 build:
-    number: 1
+    number: 3
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]
@@ -18,8 +18,8 @@ build:
 
 requirements:
     build:
-        - cmake
         - python  # [win]
+        - cmake  # [win]
         - msinttypes  # [win and py<35]
 
 test:


### PR DESCRIPTION
Let's see if this helps with https://github.com/conda-forge/libnetcdf-feedstock/pull/1
