### PR TITLE
specify prefix with path rather than name; bump build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d
 
 build:
-    number: 3
+    number: 4
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]
@@ -25,7 +25,7 @@ requirements:
 test:
     commands:
         - test -f ${PREFIX}/lib/libz.a  # [unix]
-        - conda inspect linkages -n _test zlib  # [linux]
+        - conda inspect linkages -p ${PREFIX} zlib  # [linux]
 
 about:
     home: http://zlib.net/


### PR DESCRIPTION
This will be important when we start using conda-build 2.0, because it has a much more flexible way to specify where the build/test environments live.  Don't merge it until then, though, as I don't think conda 1.x sets PREFIX appropriately in the test phase.  Might be wrong on that, though.
