### PR TITLE
Zlib 1.2.12

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -26,3 +26,7 @@ copy %LIBRARY_LIB%\zlib.lib %LIBRARY_LIB%\zdll.lib || exit 1
 
 :: Copy license file to the source directory so conda-build can find it.
 copy %RECIPE_DIR%\license.txt %SRC_DIR%\license.txt || exit 1
+
+:: python>=3.10 depend on this being at %PREFIX%
+copy %LIBRARY_BIN%\zlib.dll %PREFIX%\zlib.dll || exit 1
+

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+export CFLAGS=$(echo ${CFLAGS} | sed 's|-O2|-O3|g')
+export CPPFLAGS=$(echo ${CPPFLAGS} | sed 's|-O2|-O3|g')
+
+MACH=$(${CC} -dumpmachine)
+if [[ ${MACH} =~ x86_64.* ]] || [[ ${MACH} =~ i?86.* ]]; then
+  export CFLAGS="${CFLAGS} -DUNALIGNED_OK"
+fi
 export CFLAGS="${CFLAGS} -fPIC"
 export CXXFLAGS="${CXXFLAGS} -fPIC"
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+c_compiler:  # [osx]
+  - clang_bootstrap  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.11" %}
+{% set version = "1.2.12" %}
 
 package:
     name: zlib
@@ -6,10 +6,10 @@ package:
 
 source:
     url: http://zlib.net/zlib-{{ version }}.tar.gz
-    sha256: c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+    sha256: 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
 
 build:
-    number: 5
+    number: 0
     run_exports:
         # mostly OK, but some scary symbol removal.  Let's try for trusting them.
         #    https://abi-laboratory.pro/tracker/timeline/zlib/
@@ -34,15 +34,14 @@ test:
 about:
     home: http://zlib.net/
     # http://zlib.net/zlib_license.html
-    license: zlib
+    license: Zlib
     summary: Massively spiffy yet delicately unobtrusive compression library
-    license_family: Other
+    license_family: Zlib
     license_file: license.txt
-    
     description: |
       zlib is designed to be a free, general-purpose, lossless data-compression
       library for use on virtually any computer hardware and operating system.
-    doc_url: http://zlib.net/manual.html
+    doc_url: https://zlib.net/manual.html
     dev_url: https://github.com/madler/zlib
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,9 @@ requirements:
     build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}  # [win32]
-        - cmake  # [win]
+        # Require `cmake-no-system` to break circular dependency;
+        # the `cmake` package on defaults requires `zstd`.
+        - cmake-no-system
         - msinttypes  # [win and vc<14]
         - make  # [not win]
     host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
     sha256: c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
 
 build:
-    number: 4
+    number: 5
     run_exports:
         # mostly OK, but some scary symbol removal.  Let's try for trusting them.
         #    https://abi-laboratory.pro/tracker/timeline/zlib/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
     sha256: c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
 
 build:
-    number: 3
+    number: 4
     run_exports:
         # mostly OK, but some scary symbol removal.  Let's try for trusting them.
         #    https://abi-laboratory.pro/tracker/timeline/zlib/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
     sha256: c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
 
 build:
-    number: 1006
+    number: 2
     run_exports:
         # mostly OK, but some scary symbol removal.  Let's try for trusting them.
         #    https://abi-laboratory.pro/tracker/timeline/zlib/
@@ -17,10 +17,10 @@ build:
 
 requirements:
     build:
+        - {{ compiler('c') }}
         - cmake  # [win]
         - msinttypes  # [win and vc<14]
-        - {{ compiler('c') }}
-        - make                  # [unix]
+        - make  # [not win]
 
 test:
     commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
     sha256: c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
 
 build:
-    number: 2
+    number: 3
     run_exports:
         # mostly OK, but some scary symbol removal.  Let's try for trusting them.
         #    https://abi-laboratory.pro/tracker/timeline/zlib/
@@ -18,9 +18,12 @@ build:
 requirements:
     build:
         - {{ compiler('c') }}
+        - {{ compiler('cxx') }}  # [win32]
         - cmake  # [win]
         - msinttypes  # [win and vc<14]
         - make  # [not win]
+    host:
+        - ripgrep
 
 test:
     commands:


### PR DESCRIPTION
Changelog:

> Version 1.2.12 has these key improvements over 1.2.11:
>
> * Fix a deflate bug when using the Z_FIXED strategy that can result in out-of-bound accesses.
> * Fix a deflate bug when the window is full in deflate_stored().
> * Speed up CRC-32 computations by a factor of 1.5 to 3.
> * Use the hardware CRC-32 instruction on ARMv8 processors.
> * Speed up crc32_combine() with powers of x tables.
> *Add crc32_combine_gen() and crc32_combine_op() for fast combines.
>
> Due to the bug fixes, any installations of 1.2.11 should be replaced with 1.2.12.