### PR TITLE
Add pkgconfig files to windows to standard location

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -42,6 +42,7 @@ cmake -G "NMake Makefiles" ^
       -D CMAKE_BUILD_TYPE=Release ^
       -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -D CMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% ^
+      -D INSTALL_PKGCONFIG_DIR=%LIBRARY_PREFIX%\lib\pkgconfig ^
       %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.2.12" %}
-{% set build_num = 1 %}
+{% set build_num = 2 %}
 
 package:
   name: zlib-split
@@ -91,6 +91,7 @@ outputs:
       - Library/include        # [win]
       - Library/share          # [win]
       - Library/lib            # [win]
+      - Library/lib/pkgconfig  # [win]
     test:
       requires:
         - {{ compiler('c') }}
@@ -101,9 +102,10 @@ outputs:
         - test -f ${PREFIX}/lib/libz.a            # [unix]
         - test -f ${PREFIX}/lib/libz${SHLIB_EXT}  # [unix]
         - test -f ${PREFIX}/include/zlib.h        # [unix]
-        - if not exist %LIBRARY_LIB%\zlibstatic.lib exit 1  # [win]
-        - if not exist %LIBRARY_LIB%\zlib.lib exit 1        # [win]
-        - if not exist %LIBRARY_INC%\zlib.h exit 1          # [win]
+        - if not exist %LIBRARY_LIB%\zlibstatic.lib exit 1     # [win]
+        - if not exist %LIBRARY_LIB%\zlib.lib exit 1           # [win]
+        - if not exist %LIBRARY_LIB%\pkgconfig\zlib.pc exit 1  # [win]
+        - if not exist %LIBRARY_INC%\zlib.h exit 1             # [win]
         - call test_compile_flags.bat  # [win]
 
   - name: zlib-wapi


### PR DESCRIPTION
Would it be ok to move the pkgconfig file to the standard location where we keep the others on windows?

That is Library/lib/pkgconifg

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
